### PR TITLE
character limit and primary key change

### DIFF
--- a/backend/src/main/java/org/slash/models/Item.java
+++ b/backend/src/main/java/org/slash/models/Item.java
@@ -28,13 +28,15 @@ public class Item {
 //    @Id
 //    @GeneratedValue
 //    private Long id;
-    @Id
-    @Column(length = 512 )
+
+    
+    @Column(columnDefinition="text", length=10485760) //because was me giving error in the length of name 
     public String name;
     public String itemType;
-    @Column(length = 512 )
+    @Column(columnDefinition="text", length=10485760)
+    @Id           //because primary_key on name caused error it had mutiple same instance  
     public String itemURl;
-    @Column(length = 512 )
+    @Column (columnDefinition="text", length=10485760)
     public String itemImageURl;
     public String store;
     public String price;


### PR DESCRIPTION
Minor changes were made in item.java  because was receiving errors while scraping.
Was receiving an error of 512 character limit and also an error in the primary key, so changed the primary key from name to URL link. 
We can create another column consisting of a unique number so that we can define it as id or we can just let the url link be the primary key.