### PR TITLE
make additions to backend for extra filtering

### DIFF
--- a/backend/src/main/java/org/slash/ItemResource.java
+++ b/backend/src/main/java/org/slash/ItemResource.java
@@ -22,8 +22,19 @@ public class ItemResource {
     }
     @GET
     @Path("/{itemtype}")
-    public List<Item> getByItem(@PathParam("itemtype") String itemType) {
+    public List<Item> getByItem(@PathParam("itemtype") String itemType ) {
         return itemRepository.list("itemType",itemType);
+    }
+    @GET
+    @Path("/{store}")
+    public List<Item> getByStore(@PathParam("store") String store) {
+        return itemRepository.list("store",store);
+    }
+    @GET
+    @Path("/{itemtype}/{store}")
+    public List<Item> getByItemAndStore(@PathParam("itemtype") String itemType, @PathParam("store") String store) {
+        return itemRepository.list("itemType = ?1 and store = ?2",itemType,store);
+
     }
     @GET
     @Produces(MediaType.TEXT_PLAIN)

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -11,3 +11,4 @@ quarkus.http.cors.origins=*
 quarkus.http.cors.headers=accept, authorization, content-type, x-requested-with, access-control-allow-origin
 quarkus.http.cors.methods=GET, OPTIONS, POST
 quarkus.hibernate-orm.database.generation=drop-and-create
+quarkus.swagger-ui.always-include=true


### PR DESCRIPTION
This Pull request adds support for 2 endpoints. 

/{store}

and 

/{itemtype}/{store}

both of which enable filtering by store and item type. 